### PR TITLE
Add IBM MQ sidecar devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "IBM MQ Test Dev Container",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace/ibmmqtest",
+  "forwardPorts": [1431, 9443],
+  "postCreateCommand": "mvn -q -DskipTests package",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "vscjava.vscode-java-pack",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/java:0-17
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity
+  mq:
+    image: icr.io/ibm-messaging/mq:latest
+    environment:
+      LICENSE: accept
+      MQ_QMGR_NAME: LPQAINT
+    ports:
+      - "1431:1414"
+      - "9443:9443"

--- a/README.md
+++ b/README.md
@@ -10,5 +10,29 @@ to an ibm mq queuemanager
    -connectionList <arg>   default: localhost(1431)
    -duration <arg>         default: 5 minutes
    -queuemanager <arg>     default: LPQAINT
- 
+
  ```
+
+## Development container
+
+The repository contains a devcontainer setup that starts a Java
+development environment together with an IBM MQ sidecar container.
+The MQ queue manager is called `LPQAINT` and listens on port `1431`.
+
+To start the environment with [VS Code Dev Containers](https://containers.dev)
+or the `devcontainer` CLI, open the project in a compatible tool or run:
+
+```bash
+devcontainer up
+```
+
+After the containers are running you can build and execute the client against
+the queue manager:
+
+```bash
+mvn package
+java -jar target/ibmmqtest-0.0.1-SNAPSHOT-jar-with-dependencies.jar
+```
+
+The program will use the defaults shown above and connect to the MQ instance on
+`localhost:1431`.


### PR DESCRIPTION
## Summary
- configure a development container
- sidecar IBM MQ container exposes LPQAINT on port 1431
- document how to use the devcontainer

## Testing
- `apt-get install -y maven`
- `mvn -B package --file pom.xml` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685d094341b8832085d381c240031aa7