### PR TITLE
Fix Maven build by setting proxy

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,4 @@
+-Dhttp.proxyHost=proxy
+-Dhttp.proxyPort=8080
+-Dhttps.proxyHost=proxy
+-Dhttps.proxyPort=8080


### PR DESCRIPTION
## Summary
- add `.mvn/maven.config` to configure Maven to use the environment's HTTP/HTTPS proxy

## Testing
- `mvn -B package`

------
https://chatgpt.com/codex/tasks/task_e_684443863d408320a2067a14fd991c62