### PR TITLE
Add IBM MQ sidecar devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,27 +1,18 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/java
 {
-	"name": "Java",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/java:1-17-bookworm",
+    "name": "Java",
+    // Run the Java development container defined in docker-compose.yml
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "app",
 
-	"features": {
-		"ghcr.io/devcontainers/features/java:1": {
-			"version": "none",
-			"installMaven": "true",
-			"installGradle": "false"
-		}
-	}
+    "features": {
+        "ghcr.io/devcontainers/features/java:1": {
+            "version": "none",
+            "installMaven": "true",
+            "installGradle": "false"
+        }
+    },
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "java -version",
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+    "forwardPorts": [1431]
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/java:1-17-bookworm
+    command: sleep infinity
+    volumes:
+      - ..:/workspace:cached
+  ibmmq:
+    image: icr.io/ibm-messaging/mq:latest
+    environment:
+      - LICENSE=accept
+      - MQ_QMGR_NAME=LPQAINT
+      - MQ_APP_PASSWORD=passw0rd
+    ports:
+      - "1431:1414"

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,0 +1,4 @@
+Manifest-Version: 1.0
+Created-By: Maven JAR Plugin 3.4.1
+Build-Jdk-Spec: 17
+

--- a/META-INF/maven/ibmmqtest/ibmmqtest/pom.properties
+++ b/META-INF/maven/ibmmqtest/ibmmqtest/pom.properties
@@ -1,0 +1,3 @@
+artifactId=ibmmqtest
+groupId=ibmmqtest
+version=0.0.1-SNAPSHOT

--- a/META-INF/maven/ibmmqtest/ibmmqtest/pom.xml
+++ b/META-INF/maven/ibmmqtest/ibmmqtest/pom.xml
@@ -8,28 +8,17 @@
 	<build>
 		<plugins>
 			<plugin>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-assembly-plugin</artifactId>
-			<version>3.6.0</version>
-			<executions>
-				<execution>
-				<id>make-jar-with-dependencies</id>
-				<phase>package</phase>
-				<goals>
-					<goal>single</goal>
-				</goals>
+				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
-					<descriptorRefs>
-					<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
 					<archive>
-					<manifest>
-						<mainClass>JmsProducer</mainClass>
-					</manifest>
+						<manifest>
+                                                        <mainClass>JmsProducer</mainClass>
+						</manifest>
 					</archive>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
 				</configuration>
-				</execution>
-			</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -59,6 +48,11 @@
 			<version>7.0</version>
 		</dependency>
 
+		<dependency>
+  <groupId>javax.jms</groupId>
+  <artifactId>javax.jms-api</artifactId>
+  <version>2.0.1</version>
+</dependency>
 
 		<!-- https://mvnrepository.com/artifact/commons-cli/commons-cli -->
 		<dependency>

--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ to an ibm mq queuemanager
 
    -channel <arg>          default: LPQAINT.DVLPR.CN
    -connectionList <arg>   default: localhost(1431)
-   -duration <arg>         default: 5 minutes
-   -queuemanager <arg>     default: LPQAINT
+  -duration <arg>         default: 5 minutes
+  -queuemanager <arg>     default: LPQAINT
+  -user <arg>             MQ user name
+  -password <arg>         MQ password
 
- ```
+```
 
 ## Development container
 
@@ -32,7 +34,8 @@ The MQ container is reachable from the development container using the host
 ```bash
 mvn package
 java -cp target/ibmmqtest-0.0.1-SNAPSHOT-jar-with-dependencies.jar \
- JmsProducer -connectionList ibmmq\(1414\) -channel DEV.APP.SVRCONN
+ JmsProducer -connectionList ibmmq\(1414\) -channel DEV.APP.SVRCONN \
+ -user <username> -password <password>
 ```
 
 This connects to the sidecar queue manager using the default channel

--- a/README.md
+++ b/README.md
@@ -35,9 +35,8 @@ The MQ container is reachable from the development container using the host
 
 ```bash
 mvn package
-java -cp target/ibmmqtest-0.0.1-SNAPSHOT-jar-with-dependencies.jar \
- JmsProducer -connectionList ibmmq\(1414\) -channel DEV.APP.SVRCONN \
- -user testuser -password passw0rd
+
+java -cp target/ibmmqtest-0.0.1-SNAPSHOT-jar-with-dependencies.jar  JmsProducer -connectionList ibmmq\(1414\) -channel DEV.APP.SVRCONN  -user app -password passw0rd -destination DEV.QUEUE.1
 ```
 
 This connects to the sidecar queue manager using the default channel

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ to an ibm mq queuemanager
   -queuemanager <arg>     default: LPQAINT
   -user <arg>             MQ user name
   -password <arg>         MQ password
+  -destination <arg>      default: ADMI.INITADM
+  -destinationType <arg>  queue or topic (default: queue)
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,12 +35,33 @@ The MQ container is reachable from the development container using the host
 mvn package
 java -cp target/ibmmqtest-0.0.1-SNAPSHOT-jar-with-dependencies.jar \
  JmsProducer -connectionList ibmmq\(1414\) -channel DEV.APP.SVRCONN \
- -user <username> -password <password>
+ -user testuser -password passw0rd
 ```
 
 This connects to the sidecar queue manager using the default channel
 `LPQAINT.DVLPR.CN` and queue manager `LPQAINT`.
 
+
+
+# MQ Developer Defaults
+
+see https://github.com/ibm-messaging/mq-docker/?tab=readme-ov-file#mq-developer-defaults
+
+This image includes the MQ Developer defaults scripts which are automatically run during Queue Manager startup. This configures your Queue Manager with a set of default objects that you can use to quickly get started developing with IBM MQ. If you do not want the default objects to be created you can set the MQ_DEV environment variable to false.
+
+Users
+Userid: admin Groups: mqm Password: passw0rd
+
+Userid: app Groups: mqclient Password:
+
+Queues
+DEV.QUEUE.1
+DEV.QUEUE.2
+DEV.QUEUE.3
+DEV.DEAD.LETTER.QUEUE - Set as the Queue Manager's Dead Letter Queue.
+Channels
+DEV.ADMIN.SVRCONN - Set to only allow the admin user to connect into it and a Userid + Password must be supplied.
+DEV.APP.SVRCONN - Does not allow Administrator users to connect.
 
 see
 https://hub.docker.com/r/ibmcom/mq

--- a/README.md
+++ b/README.md
@@ -10,5 +10,30 @@ to an ibm mq queuemanager
    -connectionList <arg>   default: localhost(1431)
    -duration <arg>         default: 5 minutes
    -queuemanager <arg>     default: LPQAINT
- 
+
  ```
+
+## Development container
+
+A [devcontainer](https://containers.dev/) setup is provided. It runs this project
+alongside an IBM MQ container exposing a queue manager named `LPQAINT` on port
+`1431`.
+
+### Starting the container
+
+1. Install the **Remote - Containers** extension for Visual Studio Code.
+2. Open this repository in VS Code and choose **Reopen in Container**.
+
+### Running the client
+
+The MQ container is reachable from the development container using the host
+`ibmmq` on port `1414`. Build and run the client with:
+
+```bash
+mvn package
+java -cp target/ibmmqtest-0.0.1-SNAPSHOT-jar-with-dependencies.jar \
+  JmsProducer -connectionList ibmmq(1414)
+```
+
+This connects to the sidecar queue manager using the default channel
+`LPQAINT.DVLPR.CN` and queue manager `LPQAINT`.

--- a/README.md
+++ b/README.md
@@ -32,8 +32,12 @@ The MQ container is reachable from the development container using the host
 ```bash
 mvn package
 java -cp target/ibmmqtest-0.0.1-SNAPSHOT-jar-with-dependencies.jar \
-  JmsProducer -connectionList ibmmq(1414)
+ JmsProducer -connectionList ibmmq\(1414\) -channel DEV.APP.SVRCONN
 ```
 
 This connects to the sidecar queue manager using the default channel
 `LPQAINT.DVLPR.CN` and queue manager `LPQAINT`.
+
+
+see
+https://hub.docker.com/r/ibmcom/mq

--- a/src/main/java/JmsProducer.java
+++ b/src/main/java/JmsProducer.java
@@ -110,14 +110,15 @@ public class JmsProducer {
 			}
 			cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, queueManager);
 			if (USER_NAME != null) {
+				System.out.println("Using user name and password for authentication");
 				cf.setStringProperty(WMQConstants.USERID, USER_NAME);
 				cf.setStringProperty(WMQConstants.PASSWORD, PASSWORD);
 				cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
+			} else {
+				System.out.println("Using anonymous authentication");
 			}
-
 			// Create JMS objects
 			try (Connection connection = cf.createConnection()) {
-
 				connection.setClientID("kuhu");
 				connection.start();
 				System.out.println(testDurationMinutes + " minutes send/read test");

--- a/src/main/java/JmsProducer.java
+++ b/src/main/java/JmsProducer.java
@@ -35,9 +35,9 @@ public class JmsProducer {
 	private static final String DEFAULT_CHANNEL = "LPQAINT.DVLPR.CN";
 	private static final String DEFAULT_QUEUEMANAGER = "LPQAINT";
 
-	private static final String USER_NAME = null;
+        private static final String DEFAULT_USERNAME = null;
 
-	private static final String PASSWORD = null;
+        private static final String DEFAULT_PASSWORD = null;
 
 	private static final String DESTINATION = "ADMI.INITADM";
 
@@ -70,9 +70,17 @@ public class JmsProducer {
 				.optionalArg(true).build();
 		options.addOption(queueManagerOption);
 
-		Option durationOption = Option.builder("duration").hasArg()
-				.desc("default: " + DEFAULT_TESTDURATION + " minutes").optionalArg(true).build();
-		options.addOption(durationOption);
+                Option durationOption = Option.builder("duration").hasArg()
+                                .desc("default: " + DEFAULT_TESTDURATION + " minutes").optionalArg(true).build();
+                options.addOption(durationOption);
+
+                Option userOption = Option.builder("user").hasArg()
+                                .desc("MQ user name").optionalArg(true).build();
+                options.addOption(userOption);
+
+                Option passwordOption = Option.builder("password").hasArg()
+                                .desc("MQ password").optionalArg(true).build();
+                options.addOption(passwordOption);
 
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.printHelp(" ", options);
@@ -85,8 +93,11 @@ public class JmsProducer {
 
 		String channel = commandLine.getOptionValue(channelOption.getOpt(), DEFAULT_CHANNEL);
 		System.out.println("using channel = " + channel);
-		String queueManager = commandLine.getOptionValue(queueManagerOption.getOpt(), DEFAULT_QUEUEMANAGER);
-		System.out.println("using queueManager = " + queueManager);
+                String queueManager = commandLine.getOptionValue(queueManagerOption.getOpt(), DEFAULT_QUEUEMANAGER);
+                System.out.println("using queueManager = " + queueManager);
+
+                String user = commandLine.getOptionValue(userOption.getOpt(), DEFAULT_USERNAME);
+                String password = commandLine.getOptionValue(passwordOption.getOpt(), DEFAULT_PASSWORD);
 
 		final long testDurationMinutes = Long
 				.parseLong(commandLine.getOptionValue(durationOption.getOpt(), DEFAULT_TESTDURATION));
@@ -108,15 +119,15 @@ public class JmsProducer {
 			} else {
 				cf.setIntProperty(WMQConstants.WMQ_CONNECTION_MODE, WMQConstants.WMQ_CM_BINDINGS);
 			}
-			cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, queueManager);
-			if (USER_NAME != null) {
-				System.out.println("Using user name and password for authentication");
-				cf.setStringProperty(WMQConstants.USERID, USER_NAME);
-				cf.setStringProperty(WMQConstants.PASSWORD, PASSWORD);
-				cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
-			} else {
-				System.out.println("Using anonymous authentication");
-			}
+                        cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, queueManager);
+                        if (user != null) {
+                                System.out.println("Using user name and password for authentication");
+                                cf.setStringProperty(WMQConstants.USERID, user);
+                                cf.setStringProperty(WMQConstants.PASSWORD, password);
+                                cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
+                        } else {
+                                System.out.println("Using anonymous authentication");
+                        }
 			// Create JMS objects
 			try (Connection connection = cf.createConnection()) {
 				connection.setClientID("kuhu");


### PR DESCRIPTION
## Summary
- enable docker-compose based devcontainer configuration
- run IBM MQ as a sidecar service exposing queue manager `LPQAINT` on port 1431
- document how to use the devcontainer with the client

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d23ca50408320a431dcfae4330a67