### PR TITLE
Add MQ authentication options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ to an ibm mq queuemanager
 
    -channel <arg>          default: LPQAINT.DVLPR.CN
    -connectionList <arg>   default: localhost(1431)
-   -duration <arg>         default: 5 minutes
-   -queuemanager <arg>     default: LPQAINT
+  -duration <arg>         default: 5 minutes
+  -queuemanager <arg>     default: LPQAINT
+  -user <arg>             MQ user name
+  -password <arg>         MQ password
 
- ```
+```
 
 ## Development container
 
@@ -32,7 +34,8 @@ The MQ container is reachable from the development container using the host
 ```bash
 mvn package
 java -cp target/ibmmqtest-0.0.1-SNAPSHOT-jar-with-dependencies.jar \
- JmsProducer -connectionList ibmmq\(1414\) -channel DEV.APP.SVRCONN
+ JmsProducer -connectionList ibmmq\(1414\) -channel DEV.APP.SVRCONN \
+ -user <username> -password <password>
 ```
 
 This connects to the sidecar queue manager using the default channel

--- a/README.md
+++ b/README.md
@@ -35,12 +35,33 @@ The MQ container is reachable from the development container using the host
 mvn package
 java -cp target/ibmmqtest-0.0.1-SNAPSHOT-jar-with-dependencies.jar \
  JmsProducer -connectionList ibmmq\(1414\) -channel DEV.APP.SVRCONN \
- -user <username> -password <password>
+ -user testuser -password passw0rd
 ```
 
 This connects to the sidecar queue manager using the default channel
 `LPQAINT.DVLPR.CN` and queue manager `LPQAINT`.
 
+
+
+# MQ Developer Defaults
+
+see https://github.com/ibm-messaging/mq-docker/?tab=readme-ov-file#mq-developer-defaults
+
+This image includes the MQ Developer defaults scripts which are automatically run during Queue Manager startup. This configures your Queue Manager with a set of default objects that you can use to quickly get started developing with IBM MQ. If you do not want the default objects to be created you can set the MQ_DEV environment variable to false.
+
+Users
+Userid: admin Groups: mqm Password: passw0rd
+
+Userid: app Groups: mqclient Password:
+
+Queues
+DEV.QUEUE.1
+DEV.QUEUE.2
+DEV.QUEUE.3
+DEV.DEAD.LETTER.QUEUE - Set as the Queue Manager's Dead Letter Queue.
+Channels
+DEV.ADMIN.SVRCONN - Set to only allow the admin user to connect into it and a Userid + Password must be supplied.
+DEV.APP.SVRCONN - Does not allow Administrator users to connect.
 
 see
 https://hub.docker.com/r/ibmcom/mq

--- a/src/main/java/JmsProducer.java
+++ b/src/main/java/JmsProducer.java
@@ -35,9 +35,9 @@ public class JmsProducer {
 	private static final String DEFAULT_CHANNEL = "LPQAINT.DVLPR.CN";
 	private static final String DEFAULT_QUEUEMANAGER = "LPQAINT";
 
-	private static final String USER_NAME = null;
+        private static final String DEFAULT_USERNAME = null;
 
-	private static final String PASSWORD = null;
+        private static final String DEFAULT_PASSWORD = null;
 
 	private static final String DESTINATION = "ADMI.INITADM";
 
@@ -70,9 +70,17 @@ public class JmsProducer {
 				.optionalArg(true).build();
 		options.addOption(queueManagerOption);
 
-		Option durationOption = Option.builder("duration").hasArg()
-				.desc("default: " + DEFAULT_TESTDURATION + " minutes").optionalArg(true).build();
-		options.addOption(durationOption);
+                Option durationOption = Option.builder("duration").hasArg()
+                                .desc("default: " + DEFAULT_TESTDURATION + " minutes").optionalArg(true).build();
+                options.addOption(durationOption);
+
+                Option userOption = Option.builder("user").hasArg()
+                                .desc("MQ user name").optionalArg(true).build();
+                options.addOption(userOption);
+
+                Option passwordOption = Option.builder("password").hasArg()
+                                .desc("MQ password").optionalArg(true).build();
+                options.addOption(passwordOption);
 
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.printHelp(" ", options);
@@ -85,8 +93,11 @@ public class JmsProducer {
 
 		String channel = commandLine.getOptionValue(channelOption.getOpt(), DEFAULT_CHANNEL);
 		System.out.println("using channel = " + channel);
-		String queueManager = commandLine.getOptionValue(queueManagerOption.getOpt(), DEFAULT_QUEUEMANAGER);
-		System.out.println("using queueManager = " + queueManager);
+                String queueManager = commandLine.getOptionValue(queueManagerOption.getOpt(), DEFAULT_QUEUEMANAGER);
+                System.out.println("using queueManager = " + queueManager);
+
+                String user = commandLine.getOptionValue(userOption.getOpt(), DEFAULT_USERNAME);
+                String password = commandLine.getOptionValue(passwordOption.getOpt(), DEFAULT_PASSWORD);
 
 		final long testDurationMinutes = Long
 				.parseLong(commandLine.getOptionValue(durationOption.getOpt(), DEFAULT_TESTDURATION));
@@ -108,15 +119,15 @@ public class JmsProducer {
 			} else {
 				cf.setIntProperty(WMQConstants.WMQ_CONNECTION_MODE, WMQConstants.WMQ_CM_BINDINGS);
 			}
-			cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, queueManager);
-			if (USER_NAME != null) {
-				System.out.println("Using user name and password for authentication");
-				cf.setStringProperty(WMQConstants.USERID, USER_NAME);
-				cf.setStringProperty(WMQConstants.PASSWORD, PASSWORD);
-				cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
-			} else {
-				System.out.println("Using anonymous authentication");
-			}
+                        cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, queueManager);
+                        if (user != null) {
+                                System.out.println("Using user name and password for authentication");
+                                cf.setStringProperty(WMQConstants.USERID, user);
+                                cf.setStringProperty(WMQConstants.PASSWORD, password);
+                                cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
+                        } else {
+                                System.out.println("Using anonymous authentication");
+                        }
 			// Create JMS objects
 			try (Connection connection = cf.createConnection()) {
 				connection.setClientID("kuhu");


### PR DESCRIPTION
## Summary
- add optional `user` and `password` command line parameters
- parse credentials and configure the JMS connection factory when supplied
- document the new flags and usage in README

## Testing
- `mvn -q package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_685d30dc9ba483209d5ab71213d8f79a