### PR TITLE
Add configurable destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,8 @@ The MQ container is reachable from the development container using the host
 
 ```bash
 mvn package
-java -cp target/ibmmqtest-0.0.1-SNAPSHOT-jar-with-dependencies.jar \
- JmsProducer -connectionList ibmmq\(1414\) -channel DEV.APP.SVRCONN \
- -user testuser -password passw0rd
+
+java -cp target/ibmmqtest-0.0.1-SNAPSHOT-jar-with-dependencies.jar  JmsProducer -connectionList ibmmq\(1414\) -channel DEV.APP.SVRCONN  -user app -password passw0rd -destination DEV.QUEUE.1
 ```
 
 This connects to the sidecar queue manager using the default channel

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ to an ibm mq queuemanager
   -queuemanager <arg>     default: LPQAINT
   -user <arg>             MQ user name
   -password <arg>         MQ password
+  -destination <arg>      default: ADMI.INITADM
+  -destinationType <arg>  queue or topic (default: queue)
 
 ```
 


### PR DESCRIPTION
## Summary
- add CLI options for destination name and type
- update JmsProducer to use these options
- document new options in README

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685d4662c2d08320a5f77693e9409065